### PR TITLE
Fix issue with ignored slug field

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -18,8 +18,7 @@ exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
       Object.prototype.hasOwnProperty.call(node.frontmatter, "slug")
     ) {
       slug = `/${_.kebabCase(node.frontmatter.slug)}`;
-    }
-    if (
+    } else if (
       Object.prototype.hasOwnProperty.call(node, "frontmatter") &&
       Object.prototype.hasOwnProperty.call(node.frontmatter, "title")
     ) {


### PR DESCRIPTION
Hi! I'm trying to fix issue when the post has both the `slug` and the `title` field. Right now the `title` field value always replaces previously set `slug` field. Post path should be generated from title field only if slug field was not set. Please let me know if I've missed something here. And thanks for this awesome theme! 