### PR TITLE
fix: fixing MainNav rendering

### DIFF
--- a/content/sample-posts/2018-01-03-Big_Sample_Post/index.md
+++ b/content/sample-posts/2018-01-03-Big_Sample_Post/index.md
@@ -1,12 +1,12 @@
 ---
 title: "Big Test"
-cover: "https://unsplash.it/1280/900/?random?BigTest"
 category: "moar"
 date: "2018-01-03"
 slug: "Big-Sample_Test"
 tags:
     - test
     - huge
+    - no-cover
 ---
 
 # NOTE: This "post" is based on [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) and is meant to test styling of Markdown generated documents.

--- a/src/layouts/MainNav/MainNav.jsx
+++ b/src/layouts/MainNav/MainNav.jsx
@@ -4,11 +4,9 @@ import "./MainNav.css";
 
 class MainNav extends React.Component {
   render() {
-    const { children, overlay } = this.props;
-
-    const classes = classNames("main-nav", this.props.className, {
-      overlay
-    });
+    const { children, className } = this.props;
+    const formatting = ["overlay", "clearfix"];
+    const classes = classNames("main-nav", formatting, className);
 
     return <nav className={classes}>{children}</nav>;
   }

--- a/src/templates/author.jsx
+++ b/src/templates/author.jsx
@@ -69,7 +69,7 @@ class AuthorTemplate extends React.Component {
 
         <SiteWrapper>
           <MainHeader className="author-head" cover={cover}>
-            <MainNav overlay={cover}>
+            <MainNav>
               <BlogLogo logo={config.siteLogo} title={config.siteTitle} />
               <MenuButton
                 navigation={config.siteNavigation}

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -96,7 +96,7 @@ class PostTemplate extends React.Component {
 
         <SiteWrapper>
           <MainHeader className="post-head" cover={cover}>
-            <MainNav overlay={cover}>
+            <MainNav>
               <BlogLogo logo={config.siteLogo} title={config.siteTitle} />
               <MenuButton
                 navigation={config.siteNavigation}

--- a/src/templates/tag.jsx
+++ b/src/templates/tag.jsx
@@ -64,7 +64,7 @@ class TagTemplate extends React.Component {
           <div className="tag-template">
             {/* The big featured header */}
             <MainHeader className="tag-head" cover={tag.featureImage}>
-              <MainNav className="clearfix" overlay>
+              <MainNav>
                 <BlogLogo logo={config.siteLogo} title={config.siteTitle} />
                 <MenuButton
                   navigation={config.siteNavigation}


### PR DESCRIPTION
Adding missing ‘overlay’ and ‘clearfix’ CSS classes to MainNav to resolve render issue when no Cover image is provided.

Resolves #18