### PR TITLE
Bugfix : added import for prismjs css file to fix missing syntax highlighting

### DIFF
--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Helmet from "react-helmet";
 import config from "../../data/SiteConfig";
 import "./index.css";
+import 'prismjs/themes/prism.css'
 
 export default class MainLayout extends React.Component {
   getLocalTitle() {


### PR DESCRIPTION
Fixed syntax hl by adding missing css import for prismjs
opened an issue for this #32 

before:
<img width="802" alt="screen shot 2018-10-09 at 6 27 39 pm" src="https://user-images.githubusercontent.com/22123928/46702653-ee473100-cbf1-11e8-869d-7740effefaaa.png">

after:
<img width="865" alt="screen shot 2018-10-09 at 6 30 57 pm" src="https://user-images.githubusercontent.com/22123928/46702657-f30be500-cbf1-11e8-826e-69b501d3727d.png">
